### PR TITLE
add numbers to regex for participant handle

### DIFF
--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -76,7 +76,7 @@ class Participant < ApplicationRecord
   validates :twitter, :url => { allow_blank: true }
   validates :name,
     format: {
-      with: /\A[a-zA-Z.\-_{}\[\]]+\z/,
+      with: /\A[a-zA-Z0-9.\-_{}\[\]]+\z/,
       message: 'User handle can contain letters, numbers and these characters -_.{}[] '
     },
     length: { minimum: 2, maximum: 15 },

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -29,7 +29,7 @@ describe Participant do
 
     describe 'when handle format is valid' do
       it 'is_expected.to be valid' do
-        handles = %w(mridul_nagpal mridul.nagpal [mridulnagpal])
+        handles = %w(mridul_nagpal1 mridul.nagpal [mridulnagpal])
         handles.each do |valid_handle|
           @participant.name = valid_handle
           expect(@participant).to be_valid


### PR DESCRIPTION
My apologies I should have caught this in the PR, the new regex does not support numbers and I don't think that was intended.