### PR TITLE
enable-links-in-grading-messages

### DIFF
--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -17,4 +17,11 @@ module SubmissionsHelper
     end
   end
 
+  def enable_links_in_raw_text(text)
+    if text.nil?
+      return
+    end
+    sanitize(text.gsub(/(https?:\/\/[\S]+)/, "<a href='\\1'>\\1</a>"))
+  end
+
 end

--- a/app/views/submissions/_submission.html.erb
+++ b/app/views/submissions/_submission.html.erb
@@ -38,7 +38,7 @@
       </td>
     <% end %>
     <td class='description'>
-      <%= submission.grading_message %>
+      <%= enable_links_in_raw_text(submission.grading_message) %>
     </td>
     <td class='submission'><%= submission.created_at.strftime('%d %b %Y %H:%M:%S') %></td>
     <td class='action'>


### PR DESCRIPTION
quickest way to safely enable links.  We could also make this a markdown field but that would require adding a field to the submission table and also modifying the grader code which is generating this message.