### PR TITLE
Participant Model: Fix destroy

### DIFF
--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -30,6 +30,9 @@ class Participant < ApplicationRecord
   has_many :topics, dependent: :nullify
   has_many :comments, dependent: :nullify
   has_many :articles, dependent: :nullify
+  has_many :blogs, dependent: :nullify
+  has_many :challenge_participants,
+    dependent: :destroy
   has_many :leaderboards,
     class_name: 'Leaderboard'
   has_many :ongoing_leaderboards,


### PR DESCRIPTION
Make sure that Blogs are nullified and challenge_participant objects are destroyed when a participant is deleted