### PR TITLE
External API: Add reset time for when no slots remaining

### DIFF
--- a/app/controllers/api/external_graders_controller.rb
+++ b/app/controllers/api/external_graders_controller.rb
@@ -51,7 +51,7 @@ class Api::ExternalGradersController < Api::BaseController
       end
 
       submissions_remaining, reset_dttm = challenge.submissions_remaining(participant.id)
-      raise NoSubmissionSlotsRemaining if submissions_remaining < 1
+      raise NoSubmissionSlotsRemaining, reset_dttm if submissions_remaining < 1
       if params[:meta].present?
         params[:meta] = clean_meta(params[:meta])
       end
@@ -394,8 +394,17 @@ class Api::ExternalGradersController < Api::BaseController
   end
 
   class NoSubmissionSlotsRemaining < StandardError
-    def initialize(msg="The participant has no submission slots remaining for today.")
-      super
+    def initialize(reset_time=nil)
+      @reset_time = reset_time
+      super(message)
+    end
+
+    def message
+      if @reset_time
+        "The participant has no submission slots remaining for today. Please wait until #{@reset_time} to make your next submission."
+      else
+        "The participant has no submission slots remaining for today."
+      end
     end
   end
 
@@ -442,7 +451,7 @@ class Api::ExternalGradersController < Api::BaseController
   end
   
   class TermsNotAcceptedByParticipant < StandardError
-    def initialize(msg='Invalid Submission. Have you registered for this challenge and agreed to the participantion terms?')
+    def initialize(msg='Invalid Submission. Have you registered for this challenge and agreed to the participation terms?')
       super
     end
   end

--- a/spec/requests/api/external_graders_controller/external_graders_controller_POST_spec.rb
+++ b/spec/requests/api/external_graders_controller/external_graders_controller_POST_spec.rb
@@ -504,7 +504,7 @@ RSpec.describe Api::ExternalGradersController, type: :request do
           headers: { 'Authorization': auth_header(organizer.api_key) } }
       end
       it { expect(response).to have_http_status(400) }
-      it { expect(json(response.body)[:message]).to eq("The participant has no submission slots remaining for today.") }
+      it { expect(json(response.body)[:message]).to eq("The participant has no submission slots remaining for today. Please wait until 2017-10-30 06:02:02 UTC to make your next submission.") }
       it { expect(json(response.body)[:submission_id]).to be_nil }
       it { expect(json(response.body)[:submissions_remaining]).to eq(0) }
       if not ENV['TRAVIS']


### PR DESCRIPTION
When raising NoSubmissionSlotsRemaining, also pass the info
for when the next submission can be made.
Also small typo fix.

Closes https://github.com/AIcrowd/AIcrowd/issues/843