### PR TITLE
Fix broken ERB closing tag

### DIFF
--- a/app/views/challenges/index.html.erb
+++ b/app/views/challenges/index.html.erb
@@ -18,14 +18,9 @@
     <div class="row" id="challenges-div">
       <%= render partial: 'challenges' %>
     </div>
-
-		<% if false %> 
-    This is multiline comment hack. 
-    Uncomment this when we want pagination on this page.
-		<!-- load more -->
-		      <%= render partial: 'shared/load_more', locals: { collection: @challenges}, :id=>"load_more_link" %>
-    <!-- /load more -->
-	  <% end %>
+	  
+    <%# Uncomment this when we want pagination on this page. #>
+    <%#= render partial: 'shared/load_more', locals: { collection: @challenges}, :id=>"load_more_link" %>
 
   </div>
 </div>

--- a/app/views/challenges/index.html.erb
+++ b/app/views/challenges/index.html.erb
@@ -25,4 +25,3 @@
   </div>
 </div>
 <!-- /challenge cards -->
-</main>

--- a/app/views/challenges/index.html.erb
+++ b/app/views/challenges/index.html.erb
@@ -10,8 +10,6 @@
 </div>
 <!-- /masthead -->
 
-<%= concept(Challenge::Cell::ChallengesSubnav, @challenges, current_participant: current_participant) %>
-
 <!-- challenge cards -->
 <div class="section-pt-sm-pb-md">
   <div class="container-fluid">

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -9,7 +9,7 @@ Rails.application.configure do
   config.assets.css_compressor = :sass
   config.assets.compile = true
   config.force_ssl = true
-  config.log_level = :info
+  config.log_level = :warn
   config.log_tags = [ :request_id ]
   config.i18n.fallbacks = true
   config.log_formatter = ::Logger::Formatter.new


### PR DESCRIPTION
Haven't been able to test this, apart from the CI, and have just made the changes directly in the GitHub code editor, so please check.

- Fixes: https://github.com/AIcrowd/AIcrowd/issues/956
- Addresses: https://github.com/AIcrowd/AIcrowd/issues/909
- Removed a broken ```</main>``` tag which did not have an opening parent.
- Deleted empty ERB file and removed unused call to challenge subnav cell (in fact it was rendering it but rendering nothing)

As a general recommendation I'd consider moving away from Trailblazer cells ... they have deviated from Rails too much and are no longer well-supported. Hit me up if you want some thoughts on how to do this.

I'd also recommend putting the paging in now, perhaps using [StimulusJS](https://stimulusjs.org/) as it is Rails-friendly and perfect for these little jobs. 
