### PR TITLE
Fix count for participants, and show post-challenges switch for completed challs only

### DIFF
--- a/app/concepts/challenge/cells/statistic.rb
+++ b/app/concepts/challenge/cells/statistic.rb
@@ -19,7 +19,7 @@ class Challenge::Cell::Statistic < Challenge::Cell
     when 'view'
       formatted_count(challenge.page_views)
     when 'participant'
-      formatted_count(challenge.participant_count)
+      formatted_count(challenge.challenge_participants.size)
     when 'vote'
       formatted_count(challenge.vote_count)
     end

--- a/app/controllers/participant_challenges_controller.rb
+++ b/app/controllers/participant_challenges_controller.rb
@@ -7,7 +7,6 @@ class ParticipantChallengesController < ApplicationController
     @participant_challenges = @challenge
       .challenge_participants
       .order(updated_at: :asc)
-      .where(challenge_rules_accepted_version: @challenge.current_challenge_rules_version)
       .page(params[:page])
       .per(10)
     authorize @participant_challenges

--- a/app/jobs/update_challenge_stats_job.rb
+++ b/app/jobs/update_challenge_stats_job.rb
@@ -3,7 +3,6 @@ class UpdateChallengeStatsJob < ApplicationJob
 
   def perform
     update_submissions
-    update_participants
   end
 
   def update_submissions
@@ -16,22 +15,6 @@ class UpdateChallengeStatsJob < ApplicationJob
       ]
     result = ActiveRecord::Base.connection.execute(sql)
     logger.info("challenge submissions updated rowcount: #{result.cmd_tuples()}")
-  end
-
-
-  def update_participants
-    sql = %Q[
-      UPDATE challenges AS C
-      SET participant_count =
-          (SELECT count(DISTINCT participant_id) FROM challenge_participants cp
-            WHERE cp.challenge_id = c.id
-              AND cp.challenge_rules_accepted_version in (
-                SELECT version FROM challenge_rules cr
-                 WHERE cr.challenge_id=c.id
-              ))
-      ]
-    result = ActiveRecord::Base.connection.execute(sql)
-    logger.info("challenge participants updated, rowcount: #{result.cmd_tuples()}")
   end
 
 end

--- a/app/views/leaderboards/index.html.erb
+++ b/app/views/leaderboards/index.html.erb
@@ -43,15 +43,17 @@
       </div>
 
       <!-- toggle switch -->
-      <div class="toggle-switch-container">
-        <div class="can-toggle can-toggle--size-small">
-          <input id="post-challenge-submissions" type="checkbox">
-          <label for="post-challenge-submissions">
-            <div class="can-toggle__switch" data-checked="On" data-unchecked="Off"></div>
-            <div class="can-toggle__label-text">Show post-challenge submissions</div>
-          </label>
-        </div>
-      </div>
+	      <% if @challenge.status == :completed %>
+		      <div class="toggle-switch-container">
+			      <div class="can-toggle can-toggle--size-small">
+				      <input id="post-challenge-submissions" type="checkbox">
+				      <label for="post-challenge-submissions">
+					      <div class="can-toggle__switch" data-checked="On" data-unchecked="Off"></div>
+					      <div class="can-toggle__label-text">Show post-challenge submissions</div>
+				      </label>
+			      </div>
+		      </div>
+	      <% end %>
       <!-- /toggle switch -->
 
       <span id="more-anchor"></span>


### PR DESCRIPTION
Removed the SQL job and using challenge.challenge_participants
for the count. Also showing all the challenge_participants
on the participants tab instead of the ones that accepted
only the latest terms.

Fixes https://github.com/AIcrowd/AIcrowd/issues/958