### PR TITLE
[HOTFIX] working teams pages where names contain dots

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,8 +67,10 @@ Rails.application.routes.draw do
   resources :blogs do
     resources :votes, only: [:create, :destroy]
   end
-  resources :teams, only: [:show], param: :name, controller: 'teams/' do
-    resources :invitations, only: [:create], controller: 'teams/invitations/'
+  constraints format: false do
+    resources :teams, only: [:show], param: :name, constraints: { name: /[^?\/]+/ }, controller: 'teams/' do
+      resources :invitations, only: [:create], controller: 'teams/invitations/'
+    end
   end
   resources :team_invitations, only: [], param: :uuid do
     resources :acceptances, only: [:index, :create], controller: 'teams/invitations/acceptances'

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Teams::Controller, type: :controller do
+  render_views
+
+  let!(:challenge) { create :challenge }
+
+  context 'standard' do
+    let!(:participant) { create :participant }
+    let!(:team) { create :team, challenge: challenge, participants: [participant] }
+
+    describe 'GET #show' do
+      before { get :show, params: { name: team.name } }
+      it { expect(response).to render_template(:show) }
+      it { expect(response).to have_http_status(200) }
+    end
+  end
+
+  context 'with dotted names' do
+    let!(:participant) { create :participant, name: 'participant.withdot' }
+    let!(:team) { create :team, challenge: challenge, participants: [participant], name: 'team.withdot' }
+
+    describe 'GET #show' do
+      before do
+        # we parse an actual path instead of using shortcuts to ensure routes are working properly
+        path = team_path(name: team.name)
+        params = Rails.application.routes.recognize_path(path)
+        get(params[:action], params: params.except(:controller, :action))
+      end
+      it { expect(response).to render_template(:show) }
+      it { expect(response).to have_http_status(200) }
+    end
+  end
+end

--- a/spec/controllers/teams_invitations_controller_spec.rb
+++ b/spec/controllers/teams_invitations_controller_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe Teams::Invitations::Controller, type: :controller do
+  render_views
+
+  let!(:challenge) { create :challenge }
+
+  context 'standard' do
+    let!(:participant) { create :participant }
+    let!(:invitee) { create :participant }
+    let!(:team) { create :team, challenge: challenge, participants: [participant] }
+
+    before do
+      sign_in participant
+    end
+
+    describe 'POST #create' do
+      before { post(:create, params: { team_name: team.name, name: invitee.name }) }
+      it { expect(team.team_invitations.pluck(:invitee_id)).to eq([invitee.id]) }
+      it { expect(response).to redirect_to(team_url(name: team.name)) }
+    end
+  end
+
+  context 'with dotted names' do
+    let!(:participant) { create :participant, name: 'participant.withdot' }
+    let!(:invitee) { create :participant, name: 'invitee.withdot' }
+    let!(:team) { create :team, challenge: challenge, participants: [participant], name: 'team.withdot' }
+
+    before do
+      sign_in participant
+    end
+
+    describe 'POST #create' do
+      before do
+        # we parse an actual path instead of using shortcuts to ensure routes are working properly
+        path = team_invitations_path(team_name: team.name)
+        params = Rails.application.routes.recognize_path(path, method: :post)
+        post(params[:action], params: params.except(:controller, :action).merge(name: invitee.name))
+      end
+      it { expect(team.team_invitations.pluck(:invitee_id)).to eq([invitee.id]) }
+      it { expect(response).to redirect_to(team_url(name: team.name)) }
+    end
+  end
+end

--- a/spec/factories/team_factory.rb
+++ b/spec/factories/team_factory.rb
@@ -6,11 +6,11 @@ FactoryBot.define do
       .gsub(/[^a-zA-Z0-9.\-_{}\[\]]+/, '')
     }
 
-    trait :participants do |participants|
-      after :create do |team|
-        participants.each do |participant|
-          team.team_participants.create(participant: participant)
-        end
+    after :create do |team, evaluator|
+      first_participant = evaluator.participants&.first
+      if first_participant
+        tp = team.team_participants.find_by!(participant_id: first_participant.id)
+        tp.update_column(:role, :organizer)
       end
     end
   end


### PR DESCRIPTION
Modified the routes to allow for dotted names in `teams#show` and `team_invitations#create`
add tests for those routes (for both standard and dotted names)
change team factory to make first participant the team organizer