### PR TITLE
Fix permission issue for CLEF tasks when on organizer page

### DIFF
--- a/app/views/clef_tasks/index.html.erb
+++ b/app/views/clef_tasks/index.html.erb
@@ -16,7 +16,11 @@
             <% @clef_tasks.each do |task| %>
               <!-- task -->
               <li class="list-group-item">
-                <%= link_to task.task, organizer_clef_task_path(@organizer, task) %>
+                <% if policy(task).edit? %>
+                  <%= link_to task.task, organizer_clef_task_path(@organizer, task) %>
+                <% else %>
+                  <p><%= task.task %></p>
+                <% end %>
                 <span><%= task.task_dataset_files.count %><span> Dataset Files</span></span>
                 <% if policy(task).destroy? %>
                   <%= link_to 'Delete',

--- a/app/views/clef_tasks/show.html.erb
+++ b/app/views/clef_tasks/show.html.erb
@@ -33,9 +33,13 @@
       <div class="col-12">
         <ul class="list-group list-group-flush-px-0 list-group-dataset">
             <hr/>
-			<%= concept(TaskDataset::Cell::ListDetail, 
-				collection: @clef_task.task_dataset_files, 
-				current_participant: current_participant) %>
+			<% if policy(@clef_task).edit? %>
+				<%= concept(TaskDataset::Cell::ListDetail, 
+					collection: @clef_task.task_dataset_files, 
+					current_participant: current_participant) %>
+			<% else %>
+			 <p>Please go to the resources tab of a challenge linked to the task in order to see the dataset files</p>
+			<% end %>
         </ul>
       </div>
     </div>

--- a/app/views/organizers/_subnav.html.erb
+++ b/app/views/organizers/_subnav.html.erb
@@ -9,7 +9,7 @@
           <%= link_to 'Members', organizer_members_path(organizer), class: "nav-link nav-link-02 " + tab_class('members') %>
         </li>
       <% end %>
-      <% if organizer.clef? %>
+      <% if organizer.clef? && policy(organizer).update?%>
         <li class="nav-item">
           <%= link_to 'Tasks', organizer_clef_tasks_path(organizer), class: "nav-link nav-link-03 " +  tab_class('tasks') %>
       </li>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -647,44 +647,6 @@ ActiveRecord::Schema.define(version: 2020_01_15_123518) do
     t.integer "participant_id"
   end
 
-  create_table "migration_mappings", force: :cascade do |t|
-    t.string "source_type"
-    t.integer "source_id"
-    t.integer "crowdai_participant_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "merit_activity_logs", force: :cascade do |t|
-    t.integer "action_id"
-    t.string "related_change_type"
-    t.integer "related_change_id"
-    t.string "description"
-    t.datetime "created_at"
-  end
-
-  create_table "merit_score_points", force: :cascade do |t|
-    t.bigint "score_id"
-    t.integer "num_points", default: 0
-    t.string "log"
-    t.datetime "created_at"
-    t.index ["score_id"], name: "index_merit_score_points_on_score_id"
-  end
-
-  create_table "merit_scores", force: :cascade do |t|
-    t.bigint "sash_id"
-    t.string "category", default: "default"
-    t.index ["sash_id"], name: "index_merit_scores_on_sash_id"
-  end
-
-  create_table "migration_mappings", force: :cascade do |t|
-    t.string "source_type"
-    t.integer "source_id"
-    t.integer "crowdai_participant_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "notifications", force: :cascade do |t|
     t.bigint "participant_id"
     t.string "notification_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -647,6 +647,14 @@ ActiveRecord::Schema.define(version: 2020_01_15_123518) do
     t.integer "participant_id"
   end
 
+  create_table "migration_mappings", force: :cascade do |t|
+    t.string "source_type"
+    t.integer "source_id"
+    t.integer "crowdai_participant_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "notifications", force: :cascade do |t|
     t.bigint "participant_id"
     t.string "notification_type"


### PR DESCRIPTION
@nemaniarjun 
Discovered a bug where ordinary participants were able to see the dataset files on the organizer page, even whey they did not sign an EUA. This has been fixed now.
This PR can be safely merged, only changed permissions in some clef_specific views.