### PR TITLE
CK Editor: Small fixes, Rake Tasks

### DIFF
--- a/app/assets/javascripts/controllers/challenges_controller.js
+++ b/app/assets/javascripts/controllers/challenges_controller.js
@@ -176,20 +176,21 @@ Paloma.controller('Challenges', {
           // JQuery Object from DOM object
           heading = $(heading);
           let heading_content = heading.text();
-          heading.attr('id', heading_content);
+          let heading_id = heading_content.replace(/ /g,"_") + index;
+          heading.attr('id', heading_id);
 
           let li = $('<li/>', {
-            "class": 'nav-link',
+            "class": 'nav-item',
           }).appendTo(toc);
 
           $('<a/>', {
-            "class": 'nav-item',
-            href: "#"+heading_content,
+            "class": 'nav-link',
+            href: "#"+heading_id,
             text: _.capitalize(heading_content)
           }).appendTo(li);
 
           // Attach ScrollSpy only after the TOC has been generated.
-          if (index === headings.length) {
+          if (index === headings.length - 1) {
             $('body').scrollspy({target: "#table-of-contents", offset: 64});
           }
         });

--- a/app/assets/stylesheets/application-redesign.css.scss
+++ b/app/assets/stylesheets/application-redesign.css.scss
@@ -11678,18 +11678,18 @@ body {
   width: 20px;
 }
 
-.md-content h1 {
+.md-content h2 {
   font-size: 1.5rem;
   margin: 3rem 0 1.75rem 0;
 }
 
 @media (max-width: 767.98px) {
-  .md-content h1 {
+  .md-content h2 {
     font-size: 1.25rem;
   }
 }
 
-.md-content h2 {
+.md-content h3 {
   color: #DE4B46;
   font-size: .875rem;
   font-weight: 700;
@@ -11698,8 +11698,8 @@ body {
   margin: 2.5rem 0 1.5rem 0;
 }
 
-.md-content h1:before,
-.md-content h2:before {
+.md-content h2:before,
+.md-content h3:before {
   display: block;
   content: " ";
   margin-top: -84px;
@@ -11747,7 +11747,7 @@ body {
   padding: 0;
 }
 
-.md-content ol h1 {
+.md-content ol h2 {
   color: inherit;
   margin: 1.5rem 0 1rem 0;
 }

--- a/app/assets/stylesheets/challenges/form.scss
+++ b/app/assets/stylesheets/challenges/form.scss
@@ -3,6 +3,9 @@
 
   &__thin-tab {
     max-width: 480px;
+    .ck-editor {
+      min-width: 640px;
+    }
   }
 
   &__errors-paragraph {

--- a/lib/tasks/challenges.rake
+++ b/lib/tasks/challenges.rake
@@ -8,13 +8,33 @@ namespace :challenges do
         challenge.secondary_sort_order_cd.blank?
 
       challenge.challenge_rounds.update_all(
-        score_title:              challenge.score_title,
-        score_secondary_title:    challenge.score_secondary_title,
-        primary_sort_order_cd:    challenge.primary_sort_order_cd,
-        secondary_sort_order_cd:  challenge.secondary_sort_order_cd
+          score_title:             challenge.score_title,
+          score_secondary_title:   challenge.score_secondary_title,
+          primary_sort_order_cd:   challenge.primary_sort_order_cd,
+          secondary_sort_order_cd: challenge.secondary_sort_order_cd
       )
 
       puts "##{challenge.id} Challenge - finished migration of score titles."
     end
+  end
+
+  desc "Migrate description headings for all challenges (h1 -> h2, h2 -> h3, h3 -> h4)"
+  task migrate_all_challenge_descriptions: :environment do
+    puts "Migration for all challenge descriptions started"
+    Challenge.all.find_each do |challenge|
+      next if challenge.description.blank?
+
+      puts "Migrating description for challenge #{challenge.challenge}"
+      new_description = change_headings_in_text(challenge.description)
+      challenge.update!(description: new_description)
+    end
+  end
+
+  def change_headings_in_text(input_text)
+    8.downto(1) do |x|
+      input_text.gsub!("<h#{x}>", "<h#{x + 1}>")
+      input_text.gsub!("</h#{x}>", "</h#{x + 1}>")
+    end
+    input_text
   end
 end


### PR DESCRIPTION
This PR has the final changes required for merging CK editor for production:

1. Changes to TOC generation
2. Changes to CSS for md-content h1 -> h2, h2 -> h3 ... 
3. Rake task to update all the existing challenge description headings, h1 -> h2, h2 -> h3 ... 
4. Update to the min-width of the editor to match that of the overview page.
