### PR TITLE
Insights: Add Axis Titles + Bug Fix for single round score dropdown

### DIFF
--- a/app/javascript/stimulus_js/controllers/chart_controller.js
+++ b/app/javascript/stimulus_js/controllers/chart_controller.js
@@ -8,6 +8,7 @@ export default class extends Controller {
         this.type = this.data.get('type');
         this.currentRound = this.data.get('round');
         this.baseUrl = this.data.get('url');
+        this.defaultYTitle = this.data.get('defaultYtitle');
         this.currentScore = 'score';
         this.updateChartUrl();
     }
@@ -24,9 +25,11 @@ export default class extends Controller {
         this.currentRound = event.target.dataset.round;
         this.updateRoundTargets.forEach(target => { $(target).removeClass('active') });
         $(event.target).addClass('active');
+
         this.selectedScoreTitle = $(`.dropdown-item.chart-${this.index}.round-${this.currentRound}.${this.currentScore}`).text();
         if (!this.selectedScoreTitle){
             this.currentScore = 'score';
+
         }
         this.updateChartUrl();
     }
@@ -45,6 +48,7 @@ export default class extends Controller {
         }
 
         let params = {challenge_round_id: this.currentRound};
+
         if (this.currentScore) {
             params = {
                 challenge_round_id: this.currentRound,
@@ -56,9 +60,12 @@ export default class extends Controller {
         let progressBar = this.progressBarTarget;
         progressBar.value = 0.05;
         $(progressBar).removeClass('display-none');
+        
         new Chartkick[this.type]("chart-" + this.index, url,
             {
                 colors: ["#44B174"],
+                xtitle: 'Time',
+                ytitle: this.selectedScoreTitle || this.defaultYTitle,
                 library: { animation: {
                         duration: 2000,
                         onProgress: function(animation) {

--- a/app/views/insights/_charts/_submissions_vs_time.html.erb
+++ b/app/views/insights/_charts/_submissions_vs_time.html.erb
@@ -3,6 +3,7 @@
      data-chart-index="<%= index %>"
      data-chart-type="LineChart"
      data-chart-round="<%= challenge.active_round.id %>"
+     data-chart-default-ytitle="Submissions"
      data-chart-url="<%= submissions_vs_time_challenge_insights_path(@challenge) %>">
 
   <header class="section-header-decorative">
@@ -29,6 +30,6 @@
 
     <!-- / Challenge Round Pills  -->
   <% end %>
-  <%= line_chart submissions_vs_time_challenge_insights_path(challenge) %>
+  <%= line_chart submissions_vs_time_challenge_insights_path(challenge), xtitle: "Time", ytitle: "Submissions" %>
   <progress class="display-none" max="1" value="0" style="width: 100%" data-target="chart.progressBar"></progress>
 </div>

--- a/app/views/insights/_charts/_top_score_vs_time.html.erb
+++ b/app/views/insights/_charts/_top_score_vs_time.html.erb
@@ -3,13 +3,13 @@
      data-chart-index="<%= index %>"
      data-chart-type="AreaChart"
      data-chart-round="<%= challenge.active_round.id %>"
+     data-chart-default-ytitle="<%= challenge.active_round.get_score_title %>"
      data-chart-url="<%= top_score_vs_time_challenge_insights_path(@challenge) %>">
 
   <header class="section-header-decorative">
     <div>
       <h4>Best Score vs Time</h4>
     </div>
-    <% if challenge_rounds.size > 1 %>
       <% challenge_rounds.each do |challenge_round| %>
         <% if challenge_round.score_secondary_title.present? %>
           <div class="dropdown display-none" data-target="chart.displayScore" data-round="<%= challenge_round.id %>">
@@ -23,7 +23,6 @@
           </div>
         <% end %>
       <% end %>
-    <% end %>
   </header>
 
   <% if challenge_rounds.size > 1 %>
@@ -44,6 +43,6 @@
     </ul>
     <!-- / Challenge Round Pills  -->
   <% end %>
-  <%= area_chart top_score_vs_time_challenge_insights_path(challenge) %>
+  <%= area_chart top_score_vs_time_challenge_insights_path(challenge), xtitle: "Time", ytitle: challenge.active_round.get_score_title  %>
   <progress class="display-none" max="1" value="0" style="width: 100%" data-target="chart.progressBar"></progress>
 </div>


### PR DESCRIPTION
Added the Axis Labels for the 2 charts that we are rendering. 
Also found a bug where the score-dropdown was not showing for challenges with only 1 round. 


We need to ensure that all combinations work
1. Single Round Single Score
2. Single Round 2 scores
3. Multiple Rounds all Single score
4. Multiple Rounds all with 2 scores
5. Multiple Rounds with Single for some and 2 scores for some

I have tested locally for the above.

@spMohanty can you help test this out? Are there any other changes needed for the challenge insights page in the current version? 