### PR TITLE
Gemfile: Fix dups & simplify

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-# source 'https://rails-assets.org'
-source 'http://insecure.rails-assets.org' # something wrong with Rails assets
 
 # Rails assets gems
-gem 'rails-assets-isInViewport'
-gem 'rails-assets-jQuery-File-Upload'
+source 'https://rails-assets.org' do
+  gem 'rails-assets-isInViewport'
+  gem 'rails-assets-jQuery-File-Upload'
+end
 
 ruby '2.5.5'
 gem 'rails', '5.2.2.1'
@@ -39,12 +39,10 @@ gem 'friendly_id', '~> 5.1.0'
 gem 'fast_blank'
 gem 'font-awesome-rails'
 gem 'figaro'
-gem 'fog'
+gem 'fog-aws'
 gem 'file_validators'
 gem 'gibbon'
 gem 'groupdate'
-gem 'http'
-gem 'httparty'
 gem 'informant-rails'
 gem 'include_media_rails'
 gem 'inline_svg'
@@ -89,6 +87,7 @@ gem 'scenic', '~> 1.3'
 gem 'sprockets', '~> 4.0.0.beta8'
 gem 'social-share-button'
 gem 'sass-rails'
+gem "safely_block", "~> 0.2.2"
 gem 'skylight', '~> 3.0'
 gem 'sidekiq', '~> 5.1.1'
 gem 'sidekiq-cron', '~> 0.6.3'
@@ -156,5 +155,3 @@ group :test do
   gem 'vcr', '~> 5.0'
   gem 'webmock', '~> 3.7', '>= 3.7.6'
 end
-
-gem "safely_block", "~> 0.2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,9 +18,8 @@ GIT
 
 GEM
   remote: https://rubygems.org/
-  remote: http://insecure.rails-assets.org/
+  remote: https://rails-assets.org/
   specs:
-    CFPropertyList (2.3.6)
     actioncable (5.2.2.1)
       actionpack (= 5.2.2.1)
       nio4r (~> 2.0)
@@ -231,7 +230,6 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     doorkeeper (5.0.2)
       railties (>= 4.2)
-    dry-inflector (0.1.2)
     erbse (0.1.1)
       temple
     errbase (0.1.1)
@@ -260,62 +258,8 @@ GEM
     file_validators (2.3.0)
       activemodel (>= 3.2)
       mime-types (>= 1.0)
-    fission (0.5.0)
-      CFPropertyList (~> 2.2)
-    fog (1.41.0)
-      fog-aliyun (>= 0.1.0)
-      fog-atmos
-      fog-aws (>= 0.6.0)
-      fog-brightbox (~> 0.4)
-      fog-cloudatcost (~> 0.1.0)
-      fog-core (~> 1.45)
-      fog-digitalocean (>= 0.3.0)
-      fog-dnsimple (~> 1.0)
-      fog-dynect (~> 0.0.2)
-      fog-ecloud (~> 0.1)
-      fog-google (<= 0.1.0)
-      fog-internet-archive
-      fog-joyent
-      fog-json
-      fog-local
-      fog-openstack
-      fog-powerdns (>= 0.1.1)
-      fog-profitbricks
-      fog-rackspace
-      fog-radosgw (>= 0.0.2)
-      fog-riakcs
-      fog-sakuracloud (>= 0.0.4)
-      fog-serverlove
-      fog-softlayer
-      fog-storm_on_demand
-      fog-terremark
-      fog-vmfusion
-      fog-voxel
-      fog-vsphere (>= 0.4.0)
-      fog-xenserver
-      fog-xml (~> 0.1.1)
-      ipaddress (~> 0.5)
-      json (>= 1.8, < 2.0)
-    fog-aliyun (0.3.2)
-      fog-core
-      fog-json
-      ipaddress (~> 0.8)
-      xml-simple (~> 1.1)
-    fog-atmos (0.1.0)
-      fog-core
-      fog-xml
     fog-aws (2.0.1)
       fog-core (~> 1.38)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-      ipaddress (~> 0.8)
-    fog-brightbox (0.16.1)
-      dry-inflector
-      fog-core
-      fog-json
-      mime-types
-    fog-cloudatcost (0.1.2)
-      fog-core (~> 1.36)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
@@ -323,89 +267,9 @@ GEM
       builder
       excon (~> 0.58)
       formatador (~> 0.2)
-    fog-digitalocean (0.4.0)
-      fog-core
-      fog-json
-      fog-xml
-      ipaddress (>= 0.5)
-    fog-dnsimple (1.0.0)
-      fog-core (~> 1.38)
-      fog-json (~> 1.0)
-    fog-dynect (0.0.3)
-      fog-core
-      fog-json
-      fog-xml
-    fog-ecloud (0.3.0)
-      fog-core
-      fog-xml
-    fog-google (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-internet-archive (0.0.1)
-      fog-core
-      fog-json
-      fog-xml
-    fog-joyent (0.0.1)
-      fog-core (~> 1.42)
-      fog-json (>= 1.0)
     fog-json (1.2.0)
       fog-core
       multi_json (~> 1.10)
-    fog-local (0.6.0)
-      fog-core (>= 1.27, < 3.0)
-    fog-openstack (0.3.9)
-      fog-core (>= 1.45, <= 2.1.0)
-      fog-json (>= 1.0)
-      ipaddress (>= 0.8)
-    fog-powerdns (0.2.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-profitbricks (4.1.1)
-      fog-core (~> 1.42)
-      fog-json (~> 1.0)
-    fog-rackspace (0.1.6)
-      fog-core (>= 1.35)
-      fog-json (>= 1.0)
-      fog-xml (>= 0.1)
-      ipaddress (>= 0.8)
-    fog-radosgw (0.0.5)
-      fog-core (>= 1.21.0)
-      fog-json
-      fog-xml (>= 0.0.1)
-    fog-riakcs (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-sakuracloud (1.7.5)
-      fog-core
-      fog-json
-    fog-serverlove (0.1.2)
-      fog-core
-      fog-json
-    fog-softlayer (1.1.4)
-      fog-core
-      fog-json
-    fog-storm_on_demand (0.1.1)
-      fog-core
-      fog-json
-    fog-terremark (0.1.0)
-      fog-core
-      fog-xml
-    fog-vmfusion (0.1.0)
-      fission
-      fog-core
-    fog-voxel (0.1.0)
-      fog-core
-      fog-xml
-    fog-vsphere (2.5.0)
-      fog-core
-      rbvmomi (~> 1.9)
-    fog-xenserver (1.0.0)
-      fog-core
-      fog-xml
-      xmlrpc
     fog-xml (0.1.3)
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
@@ -719,11 +583,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rbvmomi (1.13.0)
-      builder (~> 3.0)
-      json (>= 1.8)
-      nokogiri (~> 1.5)
-      trollop (~> 2.1)
     rdoc (4.3.0)
     redis (4.1.3)
     regexp_parser (1.3.0)
@@ -879,7 +738,6 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.9)
     timecop (0.9.1)
-    trollop (2.9.9)
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -924,8 +782,6 @@ GEM
     websocket-extensions (0.1.3)
     wirb (2.1.2)
       paint (>= 0.9, < 3.0)
-    xml-simple (1.1.5)
-    xmlrpc (0.3.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -967,7 +823,7 @@ DEPENDENCIES
   ffaker
   figaro
   file_validators
-  fog
+  fog-aws
   font-awesome-rails
   friendly_id (~> 5.1.0)
   gibbon
@@ -1020,8 +876,8 @@ DEPENDENCIES
   rack (>= 2.0.6)
   rack-cors
   rails (= 5.2.2.1)
-  rails-assets-isInViewport
-  rails-assets-jQuery-File-Upload
+  rails-assets-isInViewport!
+  rails-assets-jQuery-File-Upload!
   rails-controller-testing
   rails-erd
   ransack


### PR DESCRIPTION
- Removes duplicates from the gemfile
- Uses fog-aws metagem instead of aws which installs a lot of metagems
- Moves rails-assets to a separate source block 