### PR TITLE
Update sidekiq-unique-jobs gem because 6.0.15 version was unpublished

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,7 @@ gem 'sidekiq', '~> 5.1.1'
 gem 'sidekiq-cron', '~> 0.6.3'
 gem 'sidekiq-history'
 gem 'sidekiq-failures'
-gem 'sidekiq-unique-jobs', '~> 6.0.15'
+gem 'sidekiq-unique-jobs', '~> 6.0', '>= 6.0.20'
 gem 'sinatra', '~> 2.0.2', require: nil
 gem 'stringex'
 gem 'turbolinks', '~> 5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -836,7 +836,7 @@ GEM
       sidekiq (>= 4.0.0)
     sidekiq-history (0.0.9)
       sidekiq (>= 3.0.0)
-    sidekiq-unique-jobs (6.0.15)
+    sidekiq-unique-jobs (6.0.20)
       concurrent-ruby (~> 1.0, >= 1.0.5)
       sidekiq (>= 4.0, < 7.0)
       thor (~> 0)
@@ -1047,7 +1047,7 @@ DEPENDENCIES
   sidekiq-cron (~> 0.6.3)
   sidekiq-failures
   sidekiq-history
-  sidekiq-unique-jobs (~> 6.0.15)
+  sidekiq-unique-jobs (~> 6.0, >= 6.0.20)
   simple_enum
   simplecov
   sinatra (~> 2.0.2)


### PR DESCRIPTION
sidekiq-unique-jobs 6.0.15 gem was unpublished on rubygems.org. We need to update it:
https://rubygems.org/gems/sidekiq-unique-jobs/versions