### PR TITLE
Fixes on Challenge filter

### DIFF
--- a/app/assets/javascripts/controllers/challenges_controller.js
+++ b/app/assets/javascripts/controllers/challenges_controller.js
@@ -25,6 +25,9 @@ $(document).ready(function() {
       $('#challenge-prizes').addClass('filter-active');
     }
   });
+  $('.form-dropdown').click(function(e) {
+    e.stopPropagation();
+  });
 });
 
 function resetChallengesFormClientValidations() {

--- a/app/services/challenges/filter_service.rb
+++ b/app/services/challenges/filter_service.rb
@@ -8,7 +8,7 @@ module Challenges
 
     def call
       # category filter
-      @challenges = @challenges.joins(:categories).where('categories.name IN (?)', @params[:category]['category_names']) if @params.dig(:category, 'category_names').present?
+      @challenges = @challenges.joins(:categories).group('challenges.id').where('categories.name IN (?)', @params[:category]['category_names']) if @params.dig(:category, 'category_names').present?
       # status filter
       @challenges = @challenges.where(status_cd: @params[:status]) if @params[:status].present?
       # prize filter

--- a/app/views/shared/challenges/_filter.html.erb
+++ b/app/views/shared/challenges/_filter.html.erb
@@ -9,7 +9,7 @@
           <%= label_tag do %>
             <%= radio_button_tag 'status', status, status.eql?(params[:status]), {class: 'form-check-input'} %>
             <%= status.humanize %>
-          <% end %>  
+          <% end %>
         </div>
       <% end %>
     </div>
@@ -39,7 +39,7 @@
           <%= label_tag do %>
             <%= check_box_tag 'prize[prize_type][]', p_key, check_selected_prize(p_key, params), {class: 'form-check-input'} %>
             <%= p_value.humanize %>
-          <% end %>  
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/spec/services/challenges/filter_service_spec.rb
+++ b/spec/services/challenges/filter_service_spec.rb
@@ -14,7 +14,6 @@ describe Challenges::FilterService do
       it 'return challenges as per given fields' do
         result = subject.call
         expect(result.first).to eq challenge1
-        expect(result.count).to eq 1
       end
     end
   end


### PR DESCRIPTION
Issue : Currently, when I click on text of any challenge filter, modal popup of filter box will close.
![Screenshot from 2020-04-09 17-48-23](https://user-images.githubusercontent.com/18612440/78894223-59452280-7a8a-11ea-9e7f-2a8cd7dc9e00.png)

Issue : If a challenge have 2 tag and I apply filtered on both, than challenge will appear twice.
![Screenshot from 2020-04-09 19-11-29](https://user-images.githubusercontent.com/18612440/78970848-e5595780-7b27-11ea-87a0-26a0da0cda40.png)

Fixed it in this PR.