### PR TITLE
Hide discourse category when challenge is draft or private

### DIFF
--- a/app/jobs/discourse/add_users_to_group_job.rb
+++ b/app/jobs/discourse/add_users_to_group_job.rb
@@ -1,0 +1,11 @@
+module Discourse
+  class AddUsersToGroupJob < ApplicationJob
+    queue_as :discourse
+
+    def perform(challenge_id, participants)
+      challenge = Challenge.find(challenge_id)
+
+      Discourse::AddUsersToGroupService.new(challenge: challenge, participants: participants).call
+    end
+  end
+end

--- a/app/jobs/discourse/add_users_to_group_job.rb
+++ b/app/jobs/discourse/add_users_to_group_job.rb
@@ -2,8 +2,9 @@ module Discourse
   class AddUsersToGroupJob < ApplicationJob
     queue_as :discourse
 
-    def perform(challenge_id, participants)
-      challenge = Challenge.find(challenge_id)
+    def perform(challenge_id, participants_ids)
+      challenge    = Challenge.find(challenge_id)
+      participants = Participant.where(id: participants_ids)
 
       Discourse::AddUsersToGroupService.new(challenge: challenge, participants: participants).call
     end

--- a/app/jobs/discourse/create_category_job.rb
+++ b/app/jobs/discourse/create_category_job.rb
@@ -5,6 +5,11 @@ module Discourse
     def perform(challenge_id)
       challenge = Challenge.find(challenge_id)
 
+      if challenge.hidden_in_discourse?
+        Discourse::CreateGroupService.new(challenge: challenge).call
+        Discourse::AddUsersToGroupService.new(challenge: challenge, participants: challenge.participants).call
+      end
+
       Discourse::CreateCategoryService.new(challenge: challenge).call
     end
   end

--- a/app/jobs/discourse/create_category_job.rb
+++ b/app/jobs/discourse/create_category_job.rb
@@ -7,7 +7,7 @@ module Discourse
 
       if challenge.hidden_in_discourse?
         Discourse::CreateGroupService.new(challenge: challenge).call
-        Discourse::AddUsersToGroupService.new(challenge: challenge, participants: challenge.participants).call
+        Discourse::AddUsersToGroupService.new(challenge: challenge, participants: challenge.participants_and_organizers).call
       end
 
       Discourse::CreateCategoryService.new(challenge: challenge).call

--- a/app/jobs/discourse/update_permissions_job.rb
+++ b/app/jobs/discourse/update_permissions_job.rb
@@ -1,0 +1,15 @@
+module Discourse
+  class UpdatePermissionsJob < ApplicationJob
+    queue_as :discourse
+
+    def perform(challenge_id)
+      challenge = Challenge.find(challenge_id)
+
+      Discourse::UpdateCategoryService.new(challenge: challenge).call
+
+      if challenge.hidden_in_discourse?
+        Discourse::AddUsersToGroupService.new(challenge: challenge, participants: challenge.participants_and_organizers(challenge)).call
+      end
+    end
+  end
+end

--- a/app/jobs/discourse/update_permissions_job.rb
+++ b/app/jobs/discourse/update_permissions_job.rb
@@ -8,7 +8,7 @@ module Discourse
       Discourse::UpdateCategoryService.new(challenge: challenge).call
 
       if challenge.hidden_in_discourse?
-        Discourse::AddUsersToGroupService.new(challenge: challenge, participants: challenge.participants_and_organizers(challenge)).call
+        Discourse::AddUsersToGroupService.new(challenge: challenge, participants: challenge.participants_and_organizers).call
       end
     end
   end

--- a/app/models/challenge_participant.rb
+++ b/app/models/challenge_participant.rb
@@ -11,6 +11,6 @@ class ChallengeParticipant < ApplicationRecord
     return if Rails.env.development? || Rails.env.test?
     return unless challenge.hidden_in_discourse?
 
-    Discourse::AddUsersToGroupJob.perform_later(challenge, [participant])
+    Discourse::AddUsersToGroupJob.perform_later(challenge.id, [participant.id])
   end
 end

--- a/app/models/challenge_participant.rb
+++ b/app/models/challenge_participant.rb
@@ -2,4 +2,15 @@ class ChallengeParticipant < ApplicationRecord
   belongs_to :challenge
   belongs_to :participant, optional: true
   belongs_to :clef_task, optional: true
+
+  after_commit :add_participant_to_discourse_group, on: :create
+
+  private
+
+  def add_participant_to_discourse_group
+    return if Rails.env.development? || Rails.env.test?
+    return unless challenge.hidden_in_discourse?
+
+    Discourse::AddUsersToGroupJob.perform_later(challenge, [participant])
+  end
 end

--- a/app/models/challenges_organizer.rb
+++ b/app/models/challenges_organizer.rb
@@ -11,6 +11,6 @@ class ChallengesOrganizer < ApplicationRecord
   def add_organizer_to_discourse_group
     return if Rails.env.development? || Rails.env.test?
 
-    Discourse::AddUsersToGroupJob.perform_later(challenge, organizer.participants)
+    Discourse::AddUsersToGroupJob.perform_later(challenge.id, organizer.participants.ids)
   end
 end

--- a/app/models/challenges_organizer.rb
+++ b/app/models/challenges_organizer.rb
@@ -3,4 +3,14 @@ class ChallengesOrganizer < ApplicationRecord
   belongs_to :organizer, class_name: 'Organizer'
 
   validates :organizer_id, uniqueness: { scope: :challenge_id }
+
+  after_commit :add_organizer_to_discourse_group, on: :create
+
+  private
+
+  def add_organizer_to_discourse_group
+    return if Rails.env.development? || Rails.env.test?
+
+    Discourse::AddUsersToGroupJob.perform_later(challenge, organizer.participants)
+  end
 end

--- a/app/models/participant_organizer.rb
+++ b/app/models/participant_organizer.rb
@@ -11,7 +11,7 @@ class ParticipantOrganizer < ApplicationRecord
     return if Rails.env.development? || Rails.env.test?
 
     organizer.challenges.draft_or_private.find_each do |challenge|
-      Discourse::AddUsersToGroupJob.perform_later(challenge, [participant])
+      Discourse::AddUsersToGroupJob.perform_later(challenge.id, [participant.id])
     end
   end
 end

--- a/app/models/participant_organizer.rb
+++ b/app/models/participant_organizer.rb
@@ -2,4 +2,16 @@ class ParticipantOrganizer < ApplicationRecord
   belongs_to :participant
   belongs_to :organizer
   validates :organizer_id, uniqueness: { scope: :participant_id }
+
+  after_commit :add_participant_to_discourse_groups, on: :create
+
+  private
+
+  def add_participant_to_discourse_groups
+    return if Rails.env.development? || Rails.env.test?
+
+    organizer.challenges.draft_or_private.find_each do |challenge|
+      Discourse::AddUsersToGroupJob.perform_later(challenge, [participant])
+    end
+  end
 end

--- a/app/services/discourse/add_users_to_group_service.rb
+++ b/app/services/discourse/add_users_to_group_service.rb
@@ -18,6 +18,12 @@ module Discourse
         return failure(e.message) if e.message.include?('is already a member of this group')
 
         raise e
+      rescue Discourse::BadRequest => e
+        discourse_logger.error(e.message)
+        # This happens when username doesn't exist in Discourse database
+        return failure(e.message) if e.message.include?('You supplied invalid parameters to the request: usernames')
+
+        raise e
       end
     end
 

--- a/app/services/discourse/base_service.rb
+++ b/app/services/discourse/base_service.rb
@@ -3,6 +3,8 @@ module Discourse
     LOGGER_URL                  = 'log/discourse_api.log'.freeze
     CATEGORY_DEFAULT_COLOR      = '49d9e9'.freeze
     CATEGORY_DEFAULT_TEXT_COLOR = 'f0fcfd'.freeze
+    DEFAULT_GROUP_PERMISSIONS   = 1.freeze
+    DEFAULT_GROUP_NAME          = 'everyone'.freeze
 
     protected
 
@@ -32,6 +34,7 @@ module Discourse
       participants.find { |participant| participant.name == username }
     end
 
+
     def get_participants(discourse_users)
       usernames = discourse_users.map { |discourse_user| discourse_user['username'] }.uniq
 
@@ -52,8 +55,12 @@ module Discourse
 
       block.call
     rescue Discourse::Error, Discourse::UnauthenticatedError, Discourse::NotFoundError => e
-      Logger.new(::Discourse::BaseService::LOGGER_URL).error(e.message)
+      discourse_logger.error(e.message)
       failure(e.message)
+    end
+
+    def discourse_logger
+      @logger ||= Logger.new(::Discourse::BaseService::LOGGER_URL)
     end
   end
 end

--- a/app/services/discourse/create_category_service.rb
+++ b/app/services/discourse/create_category_service.rb
@@ -34,12 +34,26 @@ module Discourse
       # - category name has to be unique
       # - slug has to be unique
       client.post(
-        '/categories.json', {
-          name:       truncated_string(challenge.challenge, ensure_uniqueness),
-          color:      ::Discourse::BaseService::CATEGORY_DEFAULT_COLOR,
-          text_color: ::Discourse::BaseService::CATEGORY_DEFAULT_TEXT_COLOR
-        }
+        '/categories.json', category_request_payload(ensure_uniqueness)
       )
+    end
+
+    def category_request_payload(ensure_uniqueness)
+      payload = {
+        name:       truncated_string(challenge.challenge, ensure_uniqueness),
+        color:      ::Discourse::BaseService::CATEGORY_DEFAULT_COLOR,
+        text_color: ::Discourse::BaseService::CATEGORY_DEFAULT_TEXT_COLOR
+      }
+
+      if challenge.discourse_group_name.present?
+        payload.merge!(
+          permissions: {
+            challenge.discourse_group_name => ::Discourse::BaseService::DEFAULT_GROUP_PERMISSIONS
+          }
+        )
+      end
+
+      payload
     end
   end
 end

--- a/app/services/discourse/create_group_service.rb
+++ b/app/services/discourse/create_group_service.rb
@@ -11,7 +11,10 @@ module Discourse
       with_discourse_errors_handling do
         response = create_group_request(ensure_uniqueness: retry_count.positive?)
 
-        challenge.update!(discourse_group_id: response.body['basic_group']['id'])
+        challenge.update!(
+          discourse_group_id:   response.body['basic_group']['id'],
+          discourse_group_name: response.body['basic_group']['name']
+        )
 
         success(response)
       rescue Discourse::UnprocessableEntity => e

--- a/db/migrate/20200422223340_add_discourse_group_name_to_challenges.rb
+++ b/db/migrate/20200422223340_add_discourse_group_name_to_challenges.rb
@@ -1,0 +1,5 @@
+class AddDiscourseGroupNameToChallenges < ActiveRecord::Migration[5.2]
+  def change
+    add_column :challenges, :discourse_group_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
 # It's strongly recommended that you check this file into your version control system.
-ActiveRecord::Schema.define(version: 2020_04_20_142821) do
+ActiveRecord::Schema.define(version: 2020_04_22_223340) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -429,6 +429,7 @@ ActiveRecord::Schema.define(version: 2020_04_20_142821) do
     t.datetime "team_freeze_time"
     t.boolean "scrollable_overview_tabs", default: true, null: false
     t.bigint "discourse_group_id"
+    t.string "discourse_group_name"
     t.index ["clef_task_id"], name: "index_challenges_on_clef_task_id"
     t.index ["slug"], name: "index_challenges_on_slug", unique: true
   end

--- a/lib/tasks/discourse.rake
+++ b/lib/tasks/discourse.rake
@@ -1,0 +1,17 @@
+namespace :discourse do
+  desc "Hide Discourse categories for hidden challenges"
+  task hide_discourse_categories_for_hidden_challenges: :environment do
+    Challenge.draft_or_private.find_each do |challenge|
+      puts "##{challenge.id} #{challenge.challenge} | Discourse category update"
+      Discourse::UpdateCategoryJob.perform_later(challenge.id)
+    end
+  end
+
+  desc "Add challenges participants to custom Discourse groups"
+  task add_challenge_participants_to_discourse_groups: :environment do
+    Challenge.where('discourse_group_name IS NOT NULL').find_each do |challenge|
+      puts "##{challenge.id} #{challenge.challenge} | Discourse group update"
+      Discourse::AddUsersToGroupJob.perform_later(challenge.id, challenge.participants_and_organizers.map(&:id))
+    end
+  end
+end

--- a/spec/services/discourse/add_users_to_group_service_spec.rb
+++ b/spec/services/discourse/add_users_to_group_service_spec.rb
@@ -48,10 +48,13 @@ describe Discourse::AddUsersToGroupService do
         let(:first_participant)  { create(:participant, name: 'random_name') }
         let(:second_participant) { create(:participant, name: 'second_randomename') }
 
-        it 'raises Discourse::BadRequest error' do
-          VCR.use_cassette('discourse_api/add_users_to_group/failure_username_does_not_exist_in_discourse') do
-            expect { subject.call }.to raise_error(Discourse::BadRequest)
+        it 'returns failure' do
+          result = VCR.use_cassette('discourse_api/add_users_to_group/failure_username_does_not_exist_in_discourse') do
+            subject.call
           end
+
+          expect(result).to be_failure
+          expect(result.value).to include('You supplied invalid parameters to the request: usernames')
         end
       end
     end

--- a/spec/services/discourse/create_group_service_spec.rb
+++ b/spec/services/discourse/create_group_service_spec.rb
@@ -19,6 +19,7 @@ describe Discourse::CreateGroupService do
 
           expect(result.success?).to eq true
           expect(challenge.reload.discourse_group_id).to eq 49
+          expect(challenge.discourse_group_name).to eq 'short-challenge-name'
         end
       end
 
@@ -38,6 +39,7 @@ describe Discourse::CreateGroupService do
 
           expect(result.success?).to eq true
           expect(challenge.reload.discourse_group_id).to eq 50
+          expect(challenge.discourse_group_name).to eq 'way-to-long-chalenge'
         end
       end
 
@@ -51,6 +53,7 @@ describe Discourse::CreateGroupService do
 
           expect(result.success?).to eq true
           expect(challenge.reload.discourse_group_id).to eq 52
+          expect(challenge.discourse_group_name).to eq 'discourse-cat-098b7a'
         end
       end
     end


### PR DESCRIPTION
Monday:
https://aicrowd.monday.com/boards/363093650/pulses/523058243

Rake tasks:
`bundle exec rake discourse:hide_discourse_categories_for_hidden_challenges`
`bundle exec rake discourse:add_challenge_participants_to_discourse_groups`

![Screenshot 2020-04-24 at 15 02 53](https://user-images.githubusercontent.com/9438445/80215485-d2bd4300-863c-11ea-804f-4aef50221283.png)
![Screenshot 2020-04-24 at 15 02 35](https://user-images.githubusercontent.com/9438445/80215491-d650ca00-863c-11ea-9d99-f3863a75d25c.png)
