### PR TITLE
Undo removal of verify_ssl=False, the endpoint is not yet stable

### DIFF
--- a/config/initializers/evaluations_api.rb
+++ b/config/initializers/evaluations_api.rb
@@ -4,5 +4,7 @@ if ENV["EVALUATIONS_API_HOST"].present?
   AIcrowdEvaluations.configure do |config|
     config.api_key['AUTHORIZATION'] = ENV["EVALUATIONS_API_KEY"]
     config.host = ENV["EVALUATIONS_API_HOST"]
+    config.verify_ssl = false
+    config.verify_ssl_host = false
   end
 end


### PR DESCRIPTION
We need to live with ssl_verify=false for now, the endpoint we are hitting doesn’t have stable HTTPS cert right now.

