### PR TITLE
Hide badge reputation on participant masthead & link to leaderboards

### DIFF
--- a/app/views/landing_page/index.html.erb
+++ b/app/views/landing_page/index.html.erb
@@ -100,9 +100,6 @@
               <%= link_to 'Top Participants', leaderboard_path, {:class => "nav-link"} %>
             </h4>
           </div>
-          <%= link_to 'See all',
-            leaderboard_path,
-            class: "btn btn-secondary btn-sm" %>
         </header>
 
         <div class="card">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -32,9 +32,6 @@
 					<li class="nav-item">
 						<%= link_to 'Challenges', challenges_path, {:class => "nav-link"} %>
 					</li>
-          <li class="nav-item">
-            <%= link_to 'User Rankings', leaderboard_path, {:class => "nav-link"} %>
-          </li>
 					<% if !SuccessStory.where(:published => true).first.nil? %>
 						<li class="nav-item">
 							<%= link_to 'Success Stories', success_stories_path, {:class => "nav-link"} %>

--- a/app/views/participants/_masthead.html.erb
+++ b/app/views/participants/_masthead.html.erb
@@ -12,7 +12,6 @@
                 <%= participant.name %>
                 <%= render partial: 'participants/show_reputation', locals: { participant: participant } %>
                 <%= render partial: 'participants/show_temporary_reputation', locals: { participant: participant } %>
-                <%= render partial: 'participants/show_badges', locals: { participant: participant } %>
               </h1>
             </div>
             <div class="masthead-info">

--- a/spec/features/challenges/participant_challenge_spec.rb
+++ b/spec/features/challenges/participant_challenge_spec.rb
@@ -42,14 +42,6 @@ describe "participant accesses challenge", :js do
       expect(page).to have_content 'Overview'
     end
 
-    it "can follow User Rankings link" do
-      within('.app-header'){
-        click_link "User Rankings"
-      }
-
-      expect(page).to have_content 'User Rankings'
-    end
-
     it "can follow Resources link" do
       click_link "Resources"
       expect(page).to have_content 'Resources'
@@ -61,14 +53,6 @@ describe "participant accesses challenge", :js do
       log_in participant
       visit '/challenges'
       click_link challenge.challenge
-    end
-
-    it "follow User Rankings link" do
-      within('.app-header'){
-        click_link "User Rankings"
-      }
-
-      expect(page).to have_content 'User Rankings'
     end
 
     it "follow Resources link" do


### PR DESCRIPTION
Both the feature needs stability, design/rendering fixes, and some more love before we expose them to end-users. 