### PR TITLE
Removed height value in truncate class

### DIFF
--- a/app/assets/stylesheets/application-redesign.css.scss
+++ b/app/assets/stylesheets/application-redesign.css.scss
@@ -10277,7 +10277,6 @@ button.bg-bronze:focus {
 }
 
 .truncate{
-   height: 16px;
    width: 125px;
    overflow: hidden;
    display: inline-block;


### PR DESCRIPTION
This is done because keeping height restriction is causing participants names to be hidden in Firefox/Chrome and we don't really care about height in truncate thing, but just the width.