### PR TITLE
Set default 1 for challenge featured_sequence

### DIFF
--- a/app/helpers/challenges_helper.rb
+++ b/app/helpers/challenges_helper.rb
@@ -181,6 +181,15 @@ module ChallengesHelper
     return link
   end
 
+  def sequence_num
+    @challenge.persisted? ? @challenge.featured_sequence : next_sequence
+  end
+
+  def next_sequence
+    max_seq = Challenge.maximum('featured_sequence') || 0
+    max_seq + 1
+  end
+
   #TODO: Generate below routes dynamically via meta programming
   def challenge_path(*args)
     path = super(*args)

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -70,6 +70,7 @@ class Challenge < ApplicationRecord
             format: { with: /\A[a-zA-Z0-9]/ }
   validates :challenge_client_name, presence: true
   validate :other_scores_fieldnames_max
+  validate :greater_than_zero
   #validate :banner_color, format: { with: /\A#?(?:[A-F0-9]{3}){1,2}\z/i }
 
   EVALUATOR_TYPES = {
@@ -192,6 +193,10 @@ class Challenge < ApplicationRecord
 
   def other_scores_fieldnames_max
     errors.add(:other_scores_fieldnames, 'A max of 5 other scores Fieldnames are allowed') if other_scores_fieldnames && (other_scores_fieldnames.count(',') > 4)
+  end
+
+  def greater_than_zero
+    errors.add(:featured_sequence, 'should be greater than zero') if featured_sequence <= 0
   end
 
   def teams_frozen?

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -196,7 +196,7 @@ class Challenge < ApplicationRecord
   end
 
   def greater_than_zero
-    errors.add(:featured_sequence, 'should be greater than zero') if featured_sequence <= 0
+    errors.add(:featured_sequence, 'should be greater than zero') if featured_sequence.to_i <= 0
   end
 
   def teams_frozen?

--- a/app/views/challenges/tabs/_details_form.html.erb
+++ b/app/views/challenges/tabs/_details_form.html.erb
@@ -52,7 +52,7 @@
   <div class="form-group">
     <span class="label-text">Featured sequence</span>
     <% if current_participant.admin? %>
-      <%= f.text_field :featured_sequence, class: "form-control" %>
+      <%= f.text_field :featured_sequence, value: sequence_num, class: "form-control" %>
     <% else %>
       <%= f.text_field :featured_sequence, readonly: true, class: "form-control" %>
     <% end %>

--- a/db/migrate/20200507094530_change_challenge_default.rb
+++ b/db/migrate/20200507094530_change_challenge_default.rb
@@ -1,0 +1,5 @@
+class ChangeChallengeDefault < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :challenges, :featured_sequence, '1'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_04_111847) do
+ActiveRecord::Schema.define(version: 2020_05_07_094530) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -397,7 +397,7 @@ ActiveRecord::Schema.define(version: 2020_05_04_111847) do
     t.text "dataset_description_markdown"
     t.text "dataset_description"
     t.string "image_file"
-    t.integer "featured_sequence", default: 0
+    t.integer "featured_sequence", default: 1
     t.boolean "dynamic_content_flag", default: false
     t.text "dynamic_content"
     t.string "dynamic_content_tab"

--- a/lib/tasks/update_featured_sequence.rake
+++ b/lib/tasks/update_featured_sequence.rake
@@ -1,0 +1,10 @@
+namespace :update_featured_sequence do
+  desc "set featured_sequence value from 0 to 1"
+  task increase_by_one: :environment do
+    challenges = Challenge.where(featured_sequence: 0)
+    challenges.each do |challenge|
+      challenge.update!(featured_sequence: 1)
+    end
+  end
+
+end

--- a/lib/tasks/update_featured_sequence.rake
+++ b/lib/tasks/update_featured_sequence.rake
@@ -1,10 +1,11 @@
 namespace :update_featured_sequence do
-  desc "set featured_sequence value from 0 to 1"
+  desc "set featured_sequence"
   task increase_by_one: :environment do
     challenges = Challenge.where(featured_sequence: 0)
     challenges.each do |challenge|
-      challenge.update!(featured_sequence: 1)
+      sleep 3
+      next_seq = Challenge.maximum('featured_sequence') + 1
+      challenge.update!(featured_sequence: next_seq)
     end
   end
-
 end

--- a/lib/tasks/update_featured_sequence.rake
+++ b/lib/tasks/update_featured_sequence.rake
@@ -3,7 +3,6 @@ namespace :update_featured_sequence do
   task increase_by_one: :environment do
     challenges = Challenge.where(featured_sequence: 0)
     challenges.each do |challenge|
-      sleep 3
       next_seq = Challenge.maximum('featured_sequence') + 1
       challenge.update!(featured_sequence: next_seq)
     end


### PR DESCRIPTION
Features Challenge ordering should not be affected by new challenge creations (etc)
Monday : https://aicrowd.monday.com/boards/363093650/pulses/546915993

Run `rake update_featured_sequence:increase_by_one`