### PR TITLE
set thumb media content type

### DIFF
--- a/app/helpers/media_helper.rb
+++ b/app/helpers/media_helper.rb
@@ -11,6 +11,17 @@ module MediaHelper
     return content_type
   end
 
+  def thumb_media_content_type(mediable)
+    return nil if mediable.media_thumbnail.nil? || !mediable.media_thumbnail.include?('.')
+
+    media     = mediable.media_thumbnail.split('.')
+    file_type = media[1]
+
+    return 'youtube' if mediable.media_content_type&.split('/')&.last == 'youtube'
+    return 'image' if ['png', 'jpg', 'gif'].include?(file_type)
+    return 'video' if ['mp4', 'webM'].include?(file_type)
+  end
+
   def media_asset(mediable, content_type, size)
     case content_type
     when nil

--- a/app/views/shared/challenges/_media.html.erb
+++ b/app/views/shared/challenges/_media.html.erb
@@ -1,6 +1,5 @@
-<% content_type = media_content_type(mediable) %>
-
-<% if ['video','image','youtube'].include?(content_type) && size == :thumb %>
+<% content_type = size == :thumb ? thumb_media_content_type(mediable) : media_content_type(mediable) %>
+<% if ['video','image','youtube'].include?(content_type) %>
   <%= link_to challenge_submission_path(mediable.challenge, submission_id) do %>
     <%= media_asset(mediable, content_type, size) %>
   <% end %>


### PR DESCRIPTION
fix thumb media-content-type for leaderboard and submission.

For test : https://aicrowd-fix-thumb-media-4pibop.herokuapp.com/challenges/neurips-2019-minerl-competition/leaderboards
Here first submission has image thumb and video as media.
but on staging I can't get AWS video and images.
let me know other way to set video media.