### PR TITLE
Bringing back baseline submission entries back to life

### DIFF
--- a/app/assets/stylesheets/application-redesign.css.scss
+++ b/app/assets/stylesheets/application-redesign.css.scss
@@ -13882,9 +13882,14 @@ html {
   padding-bottom: 15px;
 }
 
+.submission-edit-page fieldset label {
+  width: 20rem;
+}
+
 .width-72 {
   width: 72px;
 }
+
 @import '../javascripts/ckeditor/plugins/codesnippet/lib/highlight/styles/sunburst';
 @import 'challenges/form';
 @import 'challenges/datatable';

--- a/app/views/leaderboards/_leaderboards.html.erb
+++ b/app/views/leaderboards/_leaderboards.html.erb
@@ -5,6 +5,7 @@
     truncate     = truncate.present? ? truncate : false
   %>
   <tr>
+  <% if !leaderboard.baseline? %>
     <td class="leaderboard-change">
       <%= leaderboard_ranking_change(leaderboard) %>
     </td>
@@ -33,6 +34,13 @@
         <% end %>
       <% end %>
     </td>
+  <% else %>
+    <td><span class="fa fa-thumb-tack" data-toggle="tooltip" data-placement="top" title="Baseline"></span></td>
+    <td></td>
+    <td class="participant">
+      <div>Baseline <mark><%= leaderboard.baseline_comment %></mark></div>
+    </td>
+  <% end %>
 
     <% if challenge.media_on_leaderboard %>
       <td>
@@ -68,8 +76,13 @@
       <% leaderboard_other_scores_array(leaderboard, challenge).each do |other_score| %>
         <td><strong><%= other_score %></strong></td>
       <% end %>
-      <td><%= leaderboard.entries %></td>
-      <td class="text-right"><%= local_time(leaderboard.created_at, "%a, %e %b %Y %H:%M") %></td>
+
+      <% if !leaderboard.baseline? %>
+        <td><%= leaderboard.entries %></td>
+        <td class="text-right"><%= local_time(leaderboard.created_at, "%a, %e %b %Y %H:%M") %></td>
+      <% else %>
+        <td colspan="2"></td>
+      <% end %>
       <td class="text-right">
         <% if leaderboard.try(:submitter_type) != 'OldParticipant' && leaderboard.try(:submitter).present? && leaderboard.try(:submission_id).present? %>
           <%= link_to 'View', challenge_submission_path(challenge, leaderboard.submission_id), class: 'btn btn-secondary btn-sm' %>

--- a/app/views/submissions/edit.html.erb
+++ b/app/views/submissions/edit.html.erb
@@ -1,56 +1,68 @@
 <div class="content">
   <div class="masthead">
-    <div class="row">
-      <div class="info">
-        <h6><%= @challenge.challenge %></h6>
-        <h2>Update Submission</h2>
+    <div class="container-fluid">
+      <div class="row">
+        <div class="info">
+          <h6><%= @challenge.challenge %></h6>
+          <h2>Update Submission</h2>
+        </div>
       </div>
     </div>
   </div>
 
-  <div class="row">
-    <br/>
-    <label>Submission ID</label>
-    <div>
-      <%= @submission.id %>
-    </div>
-    <br/>
-    <% if @submission.participant %>
-      <label>Participant</label>
-      <div>
-        <%= link_to @submission.participant.name, participant_path(@submission.participant_id), target: :blank %>
-      </div>
-    <% end %>
-    <br/>
-    <% if @challenge.submissions_downloadable || current_participant.admin? %>
-      <% if @submission.submission_files.present? %>
-        <fieldset>
-          <label>Submission Files</label>
-          <% @submission.submission_files.each do |file| %>
-            <%= link_to "Download file #{file.id}",
-                        s3_expiring_url(file.submission_file_s3_key)
-            %><br/>
-          <% end %>
-        </fieldset>
-      <% end %>
-    <% end %>
+  <section class="section-p-sm">
+    <div class="container-fluid">
+      <div class="row submission-edit-page">
+        <div class="col-12">
+          <div class="d-flex">
+            <div class="mr-4">
+              <h4>Submission ID</h4>
+              <span><%= @submission.id %></span>
+            </div>
+            <% if @submission.participant %>
+            <div class="mr-4">
+              <h4>Participant</h4>
+              <span><%= link_to @submission.participant.name, participant_path(@submission.participant_id), target: :blank %></span>
+            </div>
+            <% end %>
+            <% if @challenge.submissions_downloadable || current_participant.admin? %>
+              <% if @submission.submission_files.present? %>
+              <div class="mr-4">
+                <h4>Submission Files</h4>
+                <span>
+                  <% @submission.submission_files.each do |file| %>
+                    <%= link_to "Download file #{file.id}",
+                                s3_expiring_url(file.submission_file_s3_key)
+                    %>&nbsp;
+                  <% end %>
+                </span>
+              </div>
+              <% end %>
+            <% end %>
 
-    <% if @submission.meta && @submission.meta.key?('repo_url') %>
-      <label>GitLab Repo</label>
-      <%= link_to @submission.meta['repo_url'], @submission.meta['repo_url'], target: :blank %><br/><br/>
-
-      <label>Ref</label>
-      <%= @submission.meta['repo_ref'] %><br/><br/>
-
-      <label>GitLab Project ID</label>
-      <%= @submission.meta['gitlab_project_id'] %><br/>
-    <% end %>
-
-    <%= form_for [@challenge, @submission],
-                 html: {
-                     class: "sgl-col",
-                     data: {controller: 'submission-baseline'}
-                 } do |f| %>
+            <% if @submission.meta && @submission.meta.key?('repo_url') %>
+              <div class="mr-4">
+                <h4>GitLab Repo</h4>
+                <span><%= link_to @submission.meta['repo_url'], @submission.meta['repo_url'], target: :blank %></span>
+              </div>
+              <div class="mr-4">
+                <h4>Ref</h4>
+                <span><%= @submission.meta['repo_ref'] %></span>
+              </div>
+              <div class="mr-4">
+                <h4>GitLab Project ID</h4>
+                <span><%= @submission.meta['gitlab_project_id'] %></span>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      
+        <div class="col-12 mt-5">
+          <%= form_for [@challenge, @submission],
+                       html: {
+                           class: "sgl-col",
+                           data: {controller: 'submission-baseline'}
+                       } do |f| %>
       <fieldset>
         <div class="twin-container">
           <div class="twin-field">
@@ -68,8 +80,8 @@
         </fieldset>
         <fieldset>
           <%= f.label :media_content_type %>
-          e.g.: image/png, video/mp4, video/youtube<br/><br/>
           <%= f.text_field :media_content_type %>
+          &nbsp;<small>e.g.: image/png, video/mp4, video/youtube</small>
         </fieldset>
         <fieldset>
           <%= f.label :media_thumbnail %>
@@ -113,13 +125,11 @@
         </fieldset>
       <% end %>
 
-      <div class="button-group">
+      <div class="button-group mt-5">
         <%= f.button "Update Submission", class: 'btn btn-primary' %> <%= link_to 'Cancel', challenge_submissions_path(@challenge), class: "btn" %>
-        <div class="twin-field">
-          <b><%= link_to 'Delete this submission', challenge_submission_path(@challenge, @submission),
-                         data: {confirm: 'Are you sure?'}, method: :delete, class: 'pull-right' %></b>
-        </div>
       </div>
     <% end %>
-  </div>
+      </div>
+    </div>
+  </section>
 </div>

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -71,6 +71,14 @@
             <%= social_share('twitter', @challenge, @submission) %>
           </div>
         </div>
+
+        <% if policy(@challenge).edit? %>
+        <div class="section-header mt-4 pt-4 border-top">
+          <div class="w-100">
+            <%= link_to 'Edit Submission', edit_challenge_submission_path(@challenge, @submission), {class: "btn btn-primary btn-sm", role:"button"} %>
+          </div>
+        </div>
+        <% end %>
       </div>
       <!-- /submission details -->
       <div class="col-sm-12 col-md-6">


### PR DESCRIPTION
Baselines look as follow on leaderboard:

![image](https://user-images.githubusercontent.com/3490586/82108026-77690700-9749-11ea-9b6d-45a67af59266.png)

Challenge edit page (still hacky and needs work, but before/after is as below, more usable for time being)

Before
![image](https://user-images.githubusercontent.com/3490586/82108042-99fb2000-9749-11ea-8d42-4160b1371e07.png)


After
![image](https://user-images.githubusercontent.com/3490586/82108033-8d76c780-9749-11ea-853d-48eddee7def8.png)

