### PR TITLE
Fix prefixed hash category filter issue

### DIFF
--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -253,12 +253,12 @@ class ChallengesController < ApplicationController
   def update_challenge_categories
     @challenge.category_challenges.destroy_all if @challenge.category_challenges.present?
     params[:challenge][:category_names].reject(&:empty?).each do |category_name|
-      begin
-        category = Category.find_or_create_by!(name: category_name)
-      rescue ActiveRecord::RecordInvalid => invalid
-        @challenge.errors.messages.merge!(invalid.record.errors.messages)
+      category = Category.find_or_create_by(name: category_name)
+      if category.save
+        @challenge.category_challenges.create!(category_id: category.id)
+      else
+        @challenge.errors.messages.merge!(category.errors.messages)
       end
-      @challenge.category_challenges.create!(category_id: category.id) if category
     end
   end
 

--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -253,8 +253,12 @@ class ChallengesController < ApplicationController
   def update_challenge_categories
     @challenge.category_challenges.destroy_all if @challenge.category_challenges.present?
     params[:challenge][:category_names].reject(&:empty?).each do |category_name|
-      category = Category.find_or_create_by!(name: category_name)
-      @challenge.category_challenges.create!(category_id: category.id)
+      begin
+        category = Category.find_or_create_by!(name: category_name)
+      rescue ActiveRecord::RecordInvalid => invalid
+        @challenge.errors.messages.merge!(invalid.record.errors.messages)
+      end
+      @challenge.category_challenges.create!(category_id: category.id) if category
     end
   end
 

--- a/app/helpers/challenges_helper.rb
+++ b/app/helpers/challenges_helper.rb
@@ -86,9 +86,9 @@ module ChallengesHelper
     raw_options        = ''
     Category.pluck(:name).each do |category_name|
       if challenge_category.include?(category_name)
-        raw_options << sanitize_html_with_attr("<option selected='selected' value='#{category_name}''>##{category_name.parameterize.underscore}</option>", elements: ['option'], attributes: {'option' => ['selected', 'value']})
+        raw_options << sanitize_html_with_attr("<option selected='selected' value='#{category_name}''>#{category_name.parameterize.underscore}</option>", elements: ['option'], attributes: {'option' => ['selected', 'value']})
       else
-        raw_options << sanitize_html_with_attr("<option value='#{category_name}''>##{category_name.parameterize.underscore}</option>", elements: ['option'], attributes: {'option' => ['value']})
+        raw_options << sanitize_html_with_attr("<option value='#{category_name}''>#{category_name.parameterize.underscore}</option>", elements: ['option'], attributes: {'option' => ['value']})
       end
     end
     raw(raw_options)

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -2,5 +2,5 @@ class Category < ApplicationRecord
   has_many :category_challenges, dependent: :destroy
   has_many :challenges, through: :category_challenges
 
-  validates :name, presence: true
+  validates :name, presence: true, format: { without: /#/, message: " => you can't add # in Tags" }
 end

--- a/lib/tasks/categories.rake
+++ b/lib/tasks/categories.rake
@@ -1,0 +1,9 @@
+namespace :category do
+  desc "Remove prefixed hash from categories"
+  task remove_prefixed_hash_from_categories: :environment do
+    prefixed_hash_categories = Category.all.where('name LIKE ?', '#%')
+    prefixed_hash_categories.each do |category|
+      category.update(name: category.name.gsub('#', ''))
+    end
+  end
+end


### PR DESCRIPTION
1. The rake task is to remove all the existing categories with prefixed hash.
2. Command to remove all existing prefixed hash categories through the rake task is `rake category:remove_prefixed_hash_from_categories`.


