### PR TITLE
Minor CSS change for card-footer (organisers display)

### DIFF
--- a/app/assets/stylesheets/application-redesign.css.scss
+++ b/app/assets/stylesheets/application-redesign.css.scss
@@ -4399,8 +4399,6 @@ input[type="button"].btn-block {
 
 .card-challenge .card-footer a {
   color: #292C2D;
-  display: flex;
-  align-items: center;
   width: 100%;
 }
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/3490586/84009138-7619ab80-a990-11ea-87b8-f30cc47404f9.png)


After:
![image](https://user-images.githubusercontent.com/3490586/84009103-6bf7ad00-a990-11ea-83c5-2cbc41d7d182.png)
