### PR TITLE
Prevent to create notification with existing notfication message

### DIFF
--- a/app/models/concerns/polymorphic_submitter.rb
+++ b/app/models/concerns/polymorphic_submitter.rb
@@ -7,4 +7,19 @@ module PolymorphicSubmitter
     has_one :participant, through: :self_ref, source: :submitter, source_type: 'Participant'
     has_one :team, through: :self_ref, source: :submitter, source_type: 'Team'
   end
+
+  def show_leaderboard?
+    return false if starting_soon_mode?
+    return false unless challenge.challenge_rounds.present?
+
+    leaderboard_public?
+  end
+
+  def starting_soon_mode?
+    challenge.status == :starting_soon
+  end
+
+  def leaderboard_public?
+    challenge.show_leaderboard == true
+  end
 end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -20,7 +20,7 @@ class NotificationService
     thumb   = @notifiable.challenge.image_file.url
     link    = challenge_submission_url(@notifiable.challenge, @notifiable.id)
 
-    existing_notification = @participant.notifications.where(notifiable: @notifiable, is_new: true).first
+    existing_notification = @participant.notifications.where(notifiable: @notifiable).first
 
     return if existing_notification.present?
 
@@ -41,7 +41,7 @@ class NotificationService
     thumb   = @notifiable.challenge.image_file.url
     link    = challenge_submission_url(@notifiable.challenge, @notifiable.id)
 
-    existing_notification = @participant.notifications.where(notifiable: @notifiable, is_new: true).first
+    existing_notification = @participant.notifications.where(notifiable: @notifiable).first
 
     return if existing_notification.present?
 
@@ -58,6 +58,8 @@ class NotificationService
   end
 
   def leaderboard
+    return unless @notifiable.show_leaderboard?
+
     return if @participant.nil? || @notifiable.previous_row_num == @notifiable.row_num
 
     # get similar unread notification of challenge
@@ -65,6 +67,9 @@ class NotificationService
     existing_notification.delete_all # delete old unread notification of this challenge
 
     message = "You have moved from #{@notifiable.previous_row_num} to #{@notifiable.row_num} place in the #{@notifiable.challenge.challenge} leaderboard"
+
+    return if @participant.notifications.where(notification_type: 'leaderboard', challenge_id: @notifiable.challenge.id, message: message).present?
+
     thumb   = @notifiable.challenge.image_file.url
     link    = challenge_leaderboards_url(@notifiable.challenge)
 

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -68,7 +68,7 @@ class NotificationService
 
     message = "You have moved from #{@notifiable.previous_row_num} to #{@notifiable.row_num} place in the #{@notifiable.challenge.challenge} leaderboard"
 
-    return if @participant.notifications.where(notification_type: 'leaderboard', challenge_id: @notifiable.challenge.id, message: message).present?
+    return if @participant.notifications.exists?(notification_type: 'leaderboard', challenge_id: @notifiable.challenge.id, message: message)
 
     thumb   = @notifiable.challenge.image_file.url
     link    = challenge_leaderboards_url(@notifiable.challenge)

--- a/lib/tasks/remove_notification.rake
+++ b/lib/tasks/remove_notification.rake
@@ -1,0 +1,13 @@
+namespace :remove_notification do
+  desc "Delete notification thats leaderboard don't have show_leaderbaord permission"
+  task leaderbaord_is_not_for_show: :environment do
+    notifications = Notification.where(notifiable_type: "Leaderboard")
+
+    notifications.each do |notification|
+      next if notification.notifiable&.show_leaderboard?
+
+      puts "Deleting notification #{notification.id} of Leaderboard #{notification.notifiable&.id}"
+      notification.delete
+    end
+  end
+end


### PR DESCRIPTION
run rake task to delete notification of leaderboard that don't have `show_leaderboard?` permission
`rake remove_notification:leaderbaord_is_not_for_show`
This rake task also delete notification that's leaderboard is not exist in DB.