### PR TITLE
:bug: updated user ratings to be returned in the order of updation, t…

### DIFF
--- a/app/queries/participant_rating_ranks_query.rb
+++ b/app/queries/participant_rating_ranks_query.rb
@@ -7,7 +7,7 @@ class ParticipantRatingRanksQuery
 
   def call()
     @relation.where('fixed_rating is not null').map do |participant|
-      user_final_rating =  UserRating.where("participant_id=#{participant.id} and rating is not null and challenge_round_id is not null").joins(:challenge_round).reorder('user_ratings.created_at desc').select("user_ratings.*, challenge_rounds.end_dttm").first
+      user_final_rating =  UserRating.where("participant_id=#{participant.id} and rating is not null and challenge_round_id is not null").joins(:challenge_round).reorder('user_ratings.updated_at desc').select("user_ratings.*, challenge_rounds.end_dttm").first
 
       next if user_final_rating.nil?
 


### PR DESCRIPTION
…o prevent variation from becoming 0.

ordering by created_at caused variance to become 0, and hence increase in ratings displayed. Changed it to updated_at.