### PR TITLE
Start using row_num instead of seq for meta leaderboard

### DIFF
--- a/app/services/calculate_meta_leaderboard_service.rb
+++ b/app/services/calculate_meta_leaderboard_service.rb
@@ -70,8 +70,8 @@ class CalculateMetaLeaderboardService
           people[key]['entries'] = 0
           people[key]['submission_id'] = entry['submission_id']
         end
-        people[key]['rank'][entry['challenge_round_id']] = {position: entry['seq'], score: entry['score']}
-        people[key]['score'] += ranking_formula(entry['seq'], entry['challenge_round_id'])
+        people[key]['rank'][entry['challenge_round_id']] = {position: entry['row_num'], score: entry['score']}
+        people[key]['score'] += ranking_formula(entry['row_num'], entry['challenge_round_id'])
         people[key]['entries'] += entry['entries']
       end
     end


### PR DESCRIPTION
`seq` has been discontinued after new leaderboard calculation logic addition, hence moving the logic on `row_num` instead of `seq`