### PR TITLE
fixing 500 error on aicrowd badges admin

### DIFF
--- a/app/admin/aicrowd_badges.rb
+++ b/app/admin/aicrowd_badges.rb
@@ -1,12 +1,5 @@
 ActiveAdmin.register AicrowdBadge do
   permit_params :id, :name, :description, :badge_type_id, :code, :badges_event_id
-
-  sidebar "Badge versions", only: [:show, :edit] do
-    ul do
-      aicrowd_badge.versions.reverse.each do |version|
-        li link_to "#{version.created_at}", admin_paper_trail_version_path(version)
-      end
-    end
-  end
+  remove_filter :versions
 
 end

--- a/app/admin/aicrowd_badges.rb
+++ b/app/admin/aicrowd_badges.rb
@@ -1,5 +1,12 @@
 ActiveAdmin.register AicrowdBadge do
   permit_params :id, :name, :description, :badge_type_id, :code, :badges_event_id
   remove_filter :versions
+  sidebar "Badge versions", only: [:show, :edit] do
+    ul do
+      aicrowd_badge.versions.reverse.each do |version|
+        li link_to "#{version.created_at}", admin_paper_trail_version_path(version)
+      end
+    end
+  end
 
 end


### PR DESCRIPTION
Currently accessing https://www.aicrowd.com/admin/aicrowd_badges is giving 500 error as pulling paper trail versions for all the badges is taking more than 18ms.
ActiveAdmin pulls all the versions for the badges for the purpose of filtering, we don't need a filter based on versioning so removed it.