### PR TITLE
Bugfix: Only use current/default leaderboard for notification generation

### DIFF
--- a/app/jobs/notification/leaderboard_notification_job.rb
+++ b/app/jobs/notification/leaderboard_notification_job.rb
@@ -4,6 +4,7 @@ class Notification::LeaderboardNotificationJob < ApplicationJob
   def perform(challenge_round_id)
     challenge_round = ChallengeRound.find(challenge_round_id)
     leaderboards    = challenge_round.leaderboards
+    leaderboards    = leaderboards.where(challenge_leaderboard_extra_id: challenge_round.default_leaderboard)
 
     leaderboards.each do |leaderboard|
       NotificationService.new(leaderboard.submitter_id, leaderboard, 'leaderboard').call


### PR DESCRIPTION
The leaderboard notifications are bit dynamic in nature, and use existing notifications, previous and current ranks, to decide the best notification to show.

Unfortunately after multi-leaderboard implementation, these checks got messed up.

And it ultimately led to ranks comparison of position A on Leaderboard X with position B on Leaderboard Y.

This commit should solve such cases, and we will be only using default leaderboard standings for the notifications. The hypothesis is the default one is generally the most important standings.
