### PR TITLE
[fix] SerializationError for Mixpanel EventJob in `registration_controller_callback`

### DIFF
--- a/app/controllers/participants/registrations_controller.rb
+++ b/app/controllers/participants/registrations_controller.rb
@@ -9,7 +9,10 @@ class Participants::RegistrationsController < Devise::RegistrationsController
   private
 
   def registration_completion_callback
-    Mixpanel::EventJob.perform_later(resource, 'Registration Complete', {
+    user = resource
+    return if user.id.nil?
+
+    Mixpanel::EventJob.perform_later(user, 'Registration Complete', {
       'Registration Method': 'Email',
     })
   end


### PR DESCRIPTION
- Return from `registration_callback_controller` if user can't be created